### PR TITLE
Fix py36 compat

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = thoughtspot_tml
-version = 1.0.15
+version = 1.0.16
 author = Bryant Howell
 author_email = bryant.howell@thoughtspot.com
 description = Library for manipulating ThoughtSpot Markup Language (TML) files

--- a/src/thoughtspot_tml/tml.py
+++ b/src/thoughtspot_tml/tml.py
@@ -11,7 +11,7 @@ import oyaml as yaml
 
 
 class TML:
-    def __init__(self, tml_ordereddict: [typing.OrderedDict, Dict]):
+    def __init__(self, tml_ordereddict: ["typing.OrderedDict", Dict]):
         self.tml = tml_ordereddict
         # Answers within a Pinboard just have an "id"
         if 'guid' in tml_ordereddict:
@@ -120,7 +120,7 @@ class TML:
                             raise IndexError("Object GUID {} not found in parent:child GUID map".format(parent_fqn))
 
 class Worksheet(TML):
-    def __init__(self, tml_ordereddict: [typing.OrderedDict, Dict]):
+    def __init__(self, tml_ordereddict: ["typing.OrderedDict", Dict]):
         super().__init__(tml_ordereddict=tml_ordereddict)
 
     @staticmethod
@@ -246,7 +246,7 @@ worksheet:
 
 
 class View(TML):
-    def __init__(self, tml_ordereddict: [typing.OrderedDict, Dict]):
+    def __init__(self, tml_ordereddict: ["typing.OrderedDict", Dict]):
         super().__init__(tml_ordereddict=tml_ordereddict)
     pass
 
@@ -260,7 +260,7 @@ class View(TML):
 
 
 class Table(TML):
-    def __init__(self, tml_ordereddict: [typing.OrderedDict, Dict]):
+    def __init__(self, tml_ordereddict: ["typing.OrderedDict", Dict]):
         super().__init__(tml_ordereddict=tml_ordereddict)
 
     @staticmethod
@@ -443,7 +443,7 @@ table:
 
 
 class Answer(TML):
-    def __init__(self, tml_ordereddict: [typing.OrderedDict, Dict]):
+    def __init__(self, tml_ordereddict: ["typing.OrderedDict", Dict]):
         super().__init__(tml_ordereddict=tml_ordereddict)
 
         class ChartTypes:
@@ -575,7 +575,7 @@ class Answer(TML):
 
 
 class Pinboard(TML):
-    def __init__(self, tml_ordereddict: [typing.OrderedDict, Dict]):
+    def __init__(self, tml_ordereddict: ["typing.OrderedDict", Dict]):
         super().__init__(tml_ordereddict=tml_ordereddict)
 
     class TileSizes:
@@ -784,7 +784,7 @@ class YAMLTML:
 
     # We use oyaml to load as an OrderedDict to maintain the order for identical output after manipulation
     @staticmethod
-    def load_string(tml_yaml_str) -> OrderedDict:
+    def load_string(tml_yaml_str) -> "typing.OrderedDict":
         return yaml.load(tml_yaml_str, Loader=yaml.Loader)
 
     # Factory method to return the correct object type


### PR DESCRIPTION
In `py35` and `py36`, function type-hints [are evaluated at runtime][pep563].

We use `typing.OrderedDict` to annotate the dependency and determinism that `oyaml` provides, but this isn't available until py37. 

This causes all downstream libraries to fail if they're using `py36`.

**Changes:**
- quoted all instances of `typing.Ordered`
- bumped version

[pep563]: https://peps.python.org/pep-0563/