### PR TITLE
YAML Serialization

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     PyYAML
-    oyaml
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = thoughtspot_tml
-version = 1.2.0
+version = 1.3.0
 author = Bryant Howell
 author_email = bryant.howell@thoughtspot.com
 description = Library for manipulating ThoughtSpot Markup Language (TML) files

--- a/src/thoughtspot_tml/_yaml.py
+++ b/src/thoughtspot_tml/_yaml.py
@@ -1,0 +1,90 @@
+from math import inf as INFINITY
+from typing import Any, Dict
+import re
+
+import yaml
+
+
+# TML column ids typically take the form..
+#
+#   LOGICAL_TABLE_NAME_#::LOGICAL_COLUMN_NAME
+#
+# Where both the logicals can contain any character except these: {}[].
+#
+_TML_ID_REGEX = re.compile(
+    r"""
+    ^              # beginning of string
+    [^"]           #   cannot start with a double quote
+    [^\[\]\{\}]+?  #     match as few characters as possible, disregarding collection characters
+    ::             #     double colon separator
+    [^\[\]\{\}]+?  #     match as few characters as possible, disregarding collection characters
+    [^"]           #   cannot end with a double quote
+    $              # end of string
+    """,
+    flags=re.VERBOSE,
+)
+
+# Reserve characters are defined as any terminator or value or flow entry token.
+_TOKEN_CHARACTERS = set("[]{}:,")
+
+# fmt: off
+# Reserve words are anything that can convert to a boolean scalar in YAML.
+_RESERVED_WORDS = (
+    "y",   # Chart Axis
+    "on",  # JOIN expressions
+)
+# fmt: on
+
+
+def _double_quote_when_special_char(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
+    """
+    Double quote the string when any condition is met.
+
+      if..
+          - it contains special tokens but not a TML ID (they don't need doublequotes!)
+          - is a reserved word
+          - it's empty
+    """
+    special = _TOKEN_CHARACTERS.intersection(set(data))
+    is_tml_id = _TML_ID_REGEX.match(data)
+    reserved = data in _RESERVED_WORDS
+    empty_str = not data
+
+    if (special and not is_tml_id) or reserved or empty_str:
+        style = '"'
+    # elif len(data.splitlines()) > 1:
+    #     style = "|"
+    else:
+        style = ""
+
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+
+yaml.add_representer(str, _double_quote_when_special_char)
+
+# BUG: pyyaml #89 ==> resolved by #635
+yaml.Loader.yaml_implicit_resolvers.pop("=")
+
+
+def load(document: str) -> Dict[str, Any]:
+    """
+    Load a TML object.
+    """
+    return yaml.load(document, Loader=yaml.SafeLoader)
+
+
+def dump(document: Any) -> str:
+    """
+    Dump a TML object as YAML.
+
+    The Java-based TML to YAML mapper includes these settings.
+
+        Feature.ALLOW_COMMENTS = true
+        Feature.MINIMIZE_QUOTES = true
+        Feature.SPLIT_LINES = false
+        Feature.WRITE_DOC_START_MARKER = false
+        Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS = true
+
+    We'll attempt to reproduce them in Python.
+    """
+    return yaml.dump(document, width=INFINITY, default_flow_style=False, sort_keys=False)


### PR DESCRIPTION
We've been using the yaml serializer in the later branch on over 15K ThoughtSpot TML objects ranging from **TS 8.4.1** - the unreleased **TS 9.1.0**. We should be safe replacing the existing implementation with this one.

- Replaced the YAML de/serializer with the V2.0 branch's version

- Scope is limited to `YAMLTML.dump_tml_object` and `YAMLTML.load_string`
  - `YAMLTML.get_tml_object` and `YAMLTML.get_tml_type` both re-use `.load_string`

- removed `oyaml` as a dependency, as of **python 3.6+** dictionary insertion order is respected
  - `pyyaml.yaml.dump` also has an argument `sort_keys=False`